### PR TITLE
Automatically setting .Pop as the transition status for .Pop transitions

### DIFF
--- a/TransitionTreasury/PushTransition/TRNavgationTransitionDelegate.swift
+++ b/TransitionTreasury/PushTransition/TRNavgationTransitionDelegate.swift
@@ -59,6 +59,9 @@ public class TRNavgationTransitionDelegate: NSObject, UINavigationControllerDele
         if operation == .Push {
             return transition
         } else if operation == .Pop {
+            if transition.transitionStatus == .Push {
+                transition.transitionStatus = .Pop
+            }
             return transition
         } else {
             return nil


### PR DESCRIPTION
If the navigationDelegate ask for the transition to use for the pop
transition after pressing the “Back”-Button, the transitions
transitonStatus now automatically gets set to .Pop (only if it used to
be .Push)

I don’t know if this might cause problems, but I find this to be the expected behaviour. 99% of the time you want to go back with the same transition as you pushed, but  I found know quick way to change the transition of the back segue to .Pop.

Also the tr_pop function behave the same way.

I checked if the transition used to be .Push, just in case the transition was customised to be something else. I don’t know if this check is necessary.

Thanks for this great library!!!
