### PR TITLE
增强TransitionInteractiveable协议扩展性

### DIFF
--- a/Demo/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Demo/Pods/Pods.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		01B6C03E3FC7274E4E9E7E53CEDDB023 /* TRViewControllerAnimatedTransitioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C42546C53D2C14FF292D58ED9A6F9F3 /* TRViewControllerAnimatedTransitioning.swift */; };
 		072AC3952AF1BEB88FB4FB7022B6E052 /* Pods-TabBarDemo-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D84F9BA5CA68BB3803786A1AA0CE99A /* Pods-TabBarDemo-dummy.m */; };
+		0AA979231EDD7748002986A7 /* DefaultPercentDrivenInteractiveTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AA979221EDD7748002986A7 /* DefaultPercentDrivenInteractiveTransition.swift */; };
 		0F91601E1324B32097B06B901159718A /* TransitionAnimationHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DB63F0A012AA4D0691A2BFFF5EBDB5 /* TransitionAnimationHelper.swift */; };
 		104C58458C6DEBCC46B8358D3CDA3320 /* TransitionAnimation-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = C9D4DA3790E2EA649C808568F55ADCD2 /* TransitionAnimation-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1294EE44CCCB3520E682D2B87A8A7D28 /* TransitionTreasury.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 68EAB9C8C350A9382FDF27FEB8D10DD6 /* TransitionTreasury.framework */; };
@@ -87,6 +88,7 @@
 /* Begin PBXFileReference section */
 		02C678B36282FA8E4E2E555146008E15 /* Pods_TabBarDemo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TabBarDemo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		063D86405F09C75FF63ACB55F3585FE6 /* TRTabBarTransitionDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TRTabBarTransitionDelegate.swift; sourceTree = "<group>"; };
+		0AA979221EDD7748002986A7 /* DefaultPercentDrivenInteractiveTransition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultPercentDrivenInteractiveTransition.swift; sourceTree = "<group>"; };
 		0D50FA71126344D071912A1054B979FD /* TransitionTreasury.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TransitionTreasury.swift; sourceTree = "<group>"; };
 		0D70BA11EC7A7E12224CC506269F311B /* TRTransitionAnimations.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TRTransitionAnimations.swift; sourceTree = "<group>"; };
 		11F22D274CCD266E7533668B5548538F /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -330,6 +332,7 @@
 		C958D9C27810285894D97572374BAA02 /* TransitionAnimation */ = {
 			isa = PBXGroup;
 			children = (
+				0AA979221EDD7748002986A7 /* DefaultPercentDrivenInteractiveTransition.swift */,
 				353F177013E72FB1F68AC20D5C8474A7 /* BlixtTransitionAnimation.swift */,
 				967852A20BDCE2FA020B27F52ED07DE7 /* DefaultPushTransitionAnimation.swift */,
 				3C0B5CD5563809ACDE0B90706802A7D8 /* ElevateTransitionAnimation.swift */,
@@ -536,6 +539,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				536C73DA1FB553922FE8F9A614264DD5 /* BlixtTransitionAnimation.swift in Sources */,
+				0AA979231EDD7748002986A7 /* DefaultPercentDrivenInteractiveTransition.swift in Sources */,
 				AABDE91769B416792E6BA50307E2DC3D /* DefaultPushTransitionAnimation.swift in Sources */,
 				310E5410D16CF9C899F6237A32CDAF92 /* ElevateTransitionAnimation.swift in Sources */,
 				EBE6A38E1F726D406A094D35D35D22E8 /* FadeTransitionAnimation.swift in Sources */,

--- a/TransitionAnimation/DefaultPercentDrivenInteractiveTransition.swift
+++ b/TransitionAnimation/DefaultPercentDrivenInteractiveTransition.swift
@@ -1,0 +1,96 @@
+//
+//  DefaultPercentDrivenInteractiveTransition.swift
+//  DefaultPercentDrivenInteractiveTransition
+//
+//  Created by John_LS on 2016/12/22.
+//  Copyright © 2016年 John_LS. All rights reserved.
+//
+
+import UIKit
+
+class DefaultPercentDrivenInteractiveTransition: UIPercentDrivenInteractiveTransition   {
+    
+    
+    ///以下是自定义交互控制器
+    var transitionContext : UIViewControllerContextTransitioning!
+    var formView : UIView!
+    var toView : UIView!
+    let x_to : CGFloat = -100.0 ///toview起始x坐标
+    
+    
+    /// 以下----自定义交互控制器
+    override func startInteractiveTransition(_ transitionContext: UIViewControllerContextTransitioning) {
+        
+        
+        let containerView = transitionContext.containerView
+        
+        guard let fromViewController = transitionContext.viewController(forKey: .from),
+            let toViewController = transitionContext.viewController(forKey: .to) else {
+                ///预防rootviewcontroller触发
+                return
+        }
+        
+        
+        self.transitionContext = transitionContext
+        
+        
+        containerView.insertSubview((toViewController.view)!, belowSubview: (fromViewController.view)!)
+        
+        
+        /// 加点阴影
+        fromViewController.view.layer.shadowOpacity = 0.8
+        fromViewController.view.layer.shadowColor = UIColor.black.cgColor
+        fromViewController.view.layer.shadowOffset = CGSize(width: 3, height: 3)
+        fromViewController.view.layer.shadowRadius = 3
+        
+        self.formView = fromViewController.view
+        self.toView = toViewController.view
+        self.toView.frame = CGRect(x:x_to,y:0,width:self.toView.frame.width,height:self.toView.frame.height)
+
+    }
+    override func update(_ percentComplete: CGFloat) {
+        
+        if transitionContext == nil {
+            ///预防rootviewcontroller触发
+            return
+        }
+        
+        self.formView?.frame = CGRect(x:(self.formView?.frame.width)!*percentComplete, y:0, width:(self.formView?.frame.width)! , height: (self.formView?.frame.height)!)
+        self.toView?.frame = CGRect(x:self.x_to+CGFloat(fabsf(Float(self.x_to*percentComplete))), y:0, width:(self.toView?.frame.width)! , height: (self.toView?.frame.height)!)
+        transitionContext?.updateInteractiveTransition(percentComplete)
+        
+    }
+    
+    
+    
+    func finishBy(cancelled: Bool) {
+        if self.transitionContext == nil {
+            ///预防rootviewcontroller触发
+            return
+        }
+        if cancelled {
+            UIView.animate(withDuration: 0.2, animations: {
+                self.formView?.frame = CGRect(x:0, y:0, width:(self.formView?.frame.width)! , height: (self.formView?.frame.height)!)
+                self.toView?.frame = CGRect(x:self.x_to, y:0, width:(self.toView?.frame.width)! , height: (self.toView?.frame.height)!)
+            }, completion: {completed in
+                self.transitionContext!.cancelInteractiveTransition()
+                self.transitionContext!.completeTransition(false)
+                self.transitionContext = nil
+                self.toView = nil
+                self.formView = nil
+            })
+        } else {
+            UIView.animate(withDuration: 0.2, animations: {
+                self.formView?.frame = CGRect(x:(self.formView?.frame.width)!, y:0, width:(self.formView?.frame.width)! , height: (self.formView?.frame.height)!)
+                self.toView?.frame = CGRect(x:0, y:0, width:(self.toView?.frame.width)! , height: (self.toView?.frame.height)!)
+            }, completion: {completed in
+                self.transitionContext!.finishInteractiveTransition()
+                self.transitionContext!.completeTransition(true)
+                self.transitionContext = nil
+                self.toView = nil
+                self.formView = nil
+            })
+        }
+    }
+    
+}

--- a/TransitionAnimation/DefaultPushTransitionAnimation.swift
+++ b/TransitionAnimation/DefaultPushTransitionAnimation.swift
@@ -14,7 +14,9 @@ open class DefaultPushTransitionAnimation: NSObject, TRViewControllerAnimatedTra
     
     open var transitionContext: UIViewControllerContextTransitioning?
     
-    open var percentTransition: UIPercentDrivenInteractiveTransition?
+    public lazy var percentTransition: UIPercentDrivenInteractiveTransition? = {
+        return DefaultPercentDrivenInteractiveTransition()
+    }()
     
     open var completion: (() -> Void)?
     
@@ -30,6 +32,12 @@ open class DefaultPushTransitionAnimation: NSObject, TRViewControllerAnimatedTra
     public init(status: TransitionStatus = .push) {
         transitionStatus = status
         super.init()
+    }
+    
+    public func finishByCancelled(_ isCancelled: Bool) {
+        if let percentTransition = percentTransition as? DefaultPercentDrivenInteractiveTransition{
+            percentTransition.finishBy(cancelled: isCancelled)
+        }
     }
     
     open func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
@@ -88,5 +96,4 @@ open class DefaultPushTransitionAnimation: NSObject, TRViewControllerAnimatedTra
                 self.cancelPop = false
         }
     }
-    
 }

--- a/TransitionTreasury/PushTransition/TRNavgationTransitionDelegate.swift
+++ b/TransitionTreasury/PushTransition/TRNavgationTransitionDelegate.swift
@@ -49,7 +49,8 @@ public class TRNavgationTransitionDelegate: NSObject, UINavigationControllerDele
         transition = method.transitionAnimation()
         super.init()
         if let transition = transition as? TransitionInteractiveable , transition.edgeSlidePop {
-            viewController?.view.addGestureRecognizer(edgePanGestureRecognizer)
+            let panGesture = transition.panGestureRecognizer ?? edgePanGestureRecognizer
+            viewController?.view.addGestureRecognizer(panGesture)
         }
     }
     
@@ -105,8 +106,9 @@ public class TRNavgationTransitionDelegate: NSObject, UINavigationControllerDele
         switch recognizer.state {
         case .began :
             transition.interacting = true
-            transition.percentTransition = UIPercentDrivenInteractiveTransition()
-            transition.percentTransition?.startInteractiveTransition((transition as! TRViewControllerAnimatedTransitioning).transitionContext!)
+            if transition.percentTransition == nil {
+                transition.percentTransition = UIPercentDrivenInteractiveTransition()
+            }
             toVC!.navigationController!.tr_popViewController()
         case .changed :
             transition.percentTransition?.update(percent)
@@ -116,10 +118,12 @@ public class TRNavgationTransitionDelegate: NSObject, UINavigationControllerDele
                 transition.cancelPop = false
                 transition.percentTransition?.completionSpeed = 1.0 - transition.percentTransition!.percentComplete
                 transition.percentTransition?.finish()
+                transition.finishByCancelled(false)
                 fromVC?.view.removeGestureRecognizer(edgePanGestureRecognizer)
             } else {
                 transition.cancelPop = true
                 transition.percentTransition?.cancel()
+                transition.finishByCancelled(true)
             }
             transition.percentTransition = nil
         }

--- a/TransitionTreasury/TRViewControllerAnimatedTransitioning.swift
+++ b/TransitionTreasury/TRViewControllerAnimatedTransitioning.swift
@@ -38,6 +38,8 @@ public protocol TransitionInteractiveable {
     var cancelPop: Bool{get set}
     /// Option
     var edgeSlidePop: Bool{get set}
+    
+    func finishByCancelled(_ isCancelled:Bool) -> Void
 }
 
 public extension TRViewControllerAnimatedTransitioning {
@@ -74,4 +76,6 @@ public extension TransitionInteractiveable {
         set {}
     }
     
+    public func finishByCancelled(_ isCancelled:Bool) -> Void {
+    }
 }


### PR DESCRIPTION
发现原来TransitionInteractiveable协议暴露的panGestureRecognizer和percentTransition属性都是在代理中直接写死而不是由使用方传入的，定制性不是特别好，此外我提到的手势返回时取消后面会黑一下的问题，派生出一个UIPercentDrivenInteractiveTransition子类也可以解决，具体原因还需要再查。