### PR TITLE
Adding support for custom TRViewControllerAnimatedTransitioning

### DIFF
--- a/TransitionAnimation/TRTransitionAnimations.swift
+++ b/TransitionAnimation/TRTransitionAnimations.swift
@@ -21,6 +21,7 @@ public enum TRPushTransitionMethod: TransitionAnimationable {
     case fade
     case page
     case blixt(keyView: UIView, to: CGRect)
+    case custom(customAnimated: TRViewControllerAnimatedTransitioning)
     case `default`
     
     public func transitionAnimation() -> TRViewControllerAnimatedTransitioning {
@@ -35,6 +36,8 @@ public enum TRPushTransitionMethod: TransitionAnimationable {
             return PageTransitionAnimation()
         case let .blixt(view, frame) :
             return BlixtTransitionAnimation(key: view, toFrame: frame)
+        case let .custom(customAnimated: TRViewControllerAnimatedTransitioning)
+            return animated
         case .default :
             return DefaultPushTransitionAnimation()
         }
@@ -56,6 +59,7 @@ public enum TRPresentTransitionMethod: TransitionAnimationable {
     case taaskyFlip(blurEffect: Bool)
     case elevate(maskView: UIView, to: CGPoint)
     case scanbot(present: UIPanGestureRecognizer?, dismiss: UIPanGestureRecognizer?)
+    case custom(customAnimated: TRViewControllerAnimatedTransitioning)
     
     public func transitionAnimation() -> TRViewControllerAnimatedTransitioning {
         switch self {
@@ -71,6 +75,8 @@ public enum TRPresentTransitionMethod: TransitionAnimationable {
             return ElevateTransitionAnimation(maskView: view, toPosition: position)
         case let .scanbot(presentGesture, dismissGesture) :
             return ScanbotTransitionAnimation(presentGesture: presentGesture, dismissGesture: dismissGesture)
+        case let .custom(customAnimated: TRViewControllerAnimatedTransitioning)
+            return animated
         }
     }
 }

--- a/TransitionAnimation/TRTransitionAnimations.swift
+++ b/TransitionAnimation/TRTransitionAnimations.swift
@@ -21,6 +21,7 @@ public enum TRPushTransitionMethod: TransitionAnimationable {
     case fade
     case page
     case blixt(keyView: UIView, to: CGRect)
+    case custom(customAnimated: TRViewControllerAnimatedTransitioning)
     case `default`
     
     public func transitionAnimation() -> TRViewControllerAnimatedTransitioning {
@@ -35,6 +36,8 @@ public enum TRPushTransitionMethod: TransitionAnimationable {
             return PageTransitionAnimation()
         case let .blixt(view, frame) :
             return BlixtTransitionAnimation(key: view, toFrame: frame)
+        case let .custom(customAnimated: TRViewControllerAnimatedTransitioning):
+            return animated
         case .default :
             return DefaultPushTransitionAnimation()
         }
@@ -56,6 +59,7 @@ public enum TRPresentTransitionMethod: TransitionAnimationable {
     case taaskyFlip(blurEffect: Bool)
     case elevate(maskView: UIView, to: CGPoint)
     case scanbot(present: UIPanGestureRecognizer?, dismiss: UIPanGestureRecognizer?)
+    case custom(customAnimated: TRViewControllerAnimatedTransitioning)
     
     public func transitionAnimation() -> TRViewControllerAnimatedTransitioning {
         switch self {
@@ -71,6 +75,8 @@ public enum TRPresentTransitionMethod: TransitionAnimationable {
             return ElevateTransitionAnimation(maskView: view, toPosition: position)
         case let .scanbot(presentGesture, dismissGesture) :
             return ScanbotTransitionAnimation(presentGesture: presentGesture, dismissGesture: dismissGesture)
+        case let .custom(customAnimated: TRViewControllerAnimatedTransitioning):
+            return animated
         }
     }
 }


### PR DESCRIPTION
Hi @DianQK, 

On the documentation you name a custom way of create animations, but currently I'm not able to make it run using a custom TRViewControllerAnimatedTransitioning on the push methods.

This PR expose **custom** into **TRPushTransitionMethod** and **TRPresentTransitionMethod** acepting an **TRViewControllerAnimatedTransitioning** as a parameter so it can be delivered at the time **transitionAnimation** is called.

Hope you merge this so we can all use custom animation :-)